### PR TITLE
[CONFIG] [Github Actions] Go coverage runtime upgraded: go 1.22.x -> …

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        go: ["1.22.x"]
+        go: ["1.23.x"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
…go 1.23.x