### PR TITLE
[CONFIG] [Github Actions] sonarcloud deprecation replacement. https:/…

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -54,7 +54,7 @@ jobs:
           verbose: true # optional (default = false)
 
       - name: Analyze with SonarCloud
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           # Needed to get PR information, if any


### PR DESCRIPTION
…/github.com/SonarSource/sonarqube-scan-action

Warning

This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action.