### PR TITLE
[CONFIG] golangci-lint upgraded.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,14 +29,9 @@ RUN  apk add --update --no-cache make nodejs npm wget \
   && npm install -g --ignore-scripts markdownlint-cli
 
 ADD https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh ${WORKDIR}/
-RUN sh install.sh -b $(go env GOPATH)/bin v1.60.3 \
+RUN sh install.sh -b $(go env GOPATH)/bin v2.0.0 \
   && rm install.sh \
   && golangci-lint --version
-
-# golangci-lint
-# RUN wget --secure-protocol=TLSv1_2 --max-redirect=0 -O- -nv \
-#   https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-#   sh -s -- -b $(go env GOPATH)/bin v1.60.3
 
 # [!TIP] Use a bind-mount to "/app" to override following "copys"
 # for lint and test against "current" sources in this stage


### PR DESCRIPTION
golangci-lint-action v6 => v7
golangci-lint cli 1.6.03 => 2.0.0
golangci-lint (docker) 1.6.03 => 2.0.0